### PR TITLE
Fix #4: Allow making screenshot of the whole screen, using multiple monitors

### DIFF
--- a/Screenshot Maker.cpp
+++ b/Screenshot Maker.cpp
@@ -23,18 +23,29 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 					  LPWSTR    lpCmdLine,
 					  int       nCmdShow)
 {
+	bool allscreens = false;
+	for (int i = 1; i < __argc; i++)
+	{
+		if (wcscmp(__wargv[i], L"-all") == 0 || wcscmp(__wargv[i], L"-a") == 0)
+		{
+			allscreens = true;
+		}
+	}
+
 	GdiplusStartupInput gdiplusStartupInput;
 	ULONG_PTR gdiplusToken;
 	GdiplusStartup(&gdiplusToken, &gdiplusStartupInput, NULL);
 
 	HWND desktop = GetDesktopWindow();
-	HDC desktopdc = GetDC(desktop);
+	HDC desktopdc = allscreens ? CreateDC(TEXT("DISPLAY"), NULL, NULL, NULL): GetDC(desktop);
 	HDC mydc = CreateCompatibleDC(desktopdc);
-	int width = GetSystemMetrics(SM_CXSCREEN);
-	int height = GetSystemMetrics(SM_CYSCREEN);
+	int width = GetSystemMetrics(allscreens? SM_CXVIRTUALSCREEN :SM_CXSCREEN);
+	int height = GetSystemMetrics(allscreens ? SM_CYVIRTUALSCREEN : SM_CYSCREEN);
+	int top = allscreens?GetSystemMetrics(SM_YVIRTUALSCREEN):0;
+	int left = allscreens ? GetSystemMetrics(SM_XVIRTUALSCREEN):0;
 	HBITMAP mybmp = CreateCompatibleBitmap(desktopdc, width, height);
 	HBITMAP oldbmp = (HBITMAP)SelectObject(mydc, mybmp);
-	BitBlt(mydc,0,0,width,height,desktopdc,0,0, SRCCOPY|CAPTUREBLT);
+	BitBlt(mydc,0,0,width,height,desktopdc,left,top, SRCCOPY|CAPTUREBLT);
 	SelectObject(mydc, oldbmp);
 
 	bool defaultfn = true;
@@ -56,6 +67,7 @@ int APIENTRY wWinMain(HINSTANCE hInstance,
 				"  -e, -encoder png          file encoder: bmp/jpeg/gif/tiff/png (default: png)\n"
 				"  -q, -quality 100          file quality for jpeg (between 0 and 100)\n"
 				"  -r, -resize 50            image size, % of the original size (between 1 and 99)\n\n"
+				"  -a, -all                  capture all screens\n\n"
 				"Copyright (c) 2009, The Mozilla Foundation\n";
 			return 0;
 		}


### PR DESCRIPTION
Add option (`-a` / `-all`) to capture all screens into a single screenshot.

**Technical background for the changes**

https://learn.microsoft.com/en-us/windows/win32/api/wingdi/nf-wingdi-createdca

> If there are multiple monitors on the system, calling CreateDC(TEXT("DISPLAY"),NULL,NULL,NULL) will create a DC covering all the monitors.

https://learn.microsoft.com/en-us/windows/win32/api/winuser/nf-winuser-getsystemmetrics

>  SM_CYVIRTUALSCREEN 
The height of the virtual screen,  in pixels. The virtual screen is the bounding rectangle of all display  monitors. 
> The SM_YVIRTUALSCREEN metric is the coordinates for the top of  the virtual screen.

The variables top and left are needed, because the top left corner of the virtual screen can have negative coordinates and doesn't need to start at 0/0.

**Building**

I don't have the old v120 build tools to check if this code is compatible.
Therefore I needed to change my .VCXPROJ to make the code compile, However, I didn't include that file in the pull request to maintain backward compatibility.
I built it with build tools v142 and the latest Windows 10 SDK.

**Testing**

I tested the `-a` option with 2 monitors, once with positive coordinates and once with negative coordinates.
I also ran it without `-a` to see whether it takes a screenshot of the primary monitor only.
I have not tried and not touched the other options.

Copying screens into clipboard with <kbd>PrintScreen</kbd> will copy transparent regions when there's space not covered by a monitor. This tool creates those regions in black. I personally don't care at the moment, though transparent would definitely be nicer. I just have no idea on how to implement that.